### PR TITLE
test: complete API test suite with integration and mocked tests

### DIFF
--- a/app.mock.test.js
+++ b/app.mock.test.js
@@ -3,10 +3,9 @@ const request = require('supertest')
 const validateUsername = require('./validation/validateUsername')
 const validatePassword = require('./validation/validatePassword')
 
-//Mock validateEmail to isolate tests
+// Mock validateEmail to avoid the intentional 2-second busy-wait
 jest.mock('./validation/validateEmail', () => {
     return jest.fn((email) => {
-        //Simulate real world simulation
         if (!email || typeof email !== 'string') return false;
         const re = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
         return re.test(email);
@@ -16,33 +15,47 @@ jest.mock('./validation/validateEmail', () => {
 const validateEmail = require('./validation/validateEmail')
 const app = createApp(validateUsername, validatePassword, validateEmail)
 
-describe('given correct username and password', () => {
-    test('return status 200', async () => {
-        const response = await request(app).post('/users').send({
-            username: 'Username',
-            password: 'Password123',
-            email: 'student@example.com'
-        })
+// ─────────────────────────────────────────────
+// VALID inputs → 200
+// ─────────────────────────────────────────────
+describe('given correct username, password and email', () => {
+    const validBody = {
+        username: 'Username',
+        password: 'Password123',
+        email: 'student@example.com'
+    }
+
+    test('returns status 200', async () => {
+        const response = await request(app).post('/users').send(validBody)
         expect(response.statusCode).toBe(200)
     })
 
-    test('returns userId', async () => {
-        const response = await request(app).post('/users').send({
-            username: 'Username',
-            password: 'Password123',
-            email: 'student@example.com'
-        })
-        expect(response.body.userId).toBeDefined();
+    test('returns JSON content-type', async () => {
+        const response = await request(app).post('/users').send(validBody)
+        expect(response.headers['content-type']).toMatch(/json/)
     })
 
-    // test response content type?
-    // test response message
-    // test response user id value
-    // ...
+    test('returns userId in body', async () => {
+        const response = await request(app).post('/users').send(validBody)
+        expect(response.body.userId).toBeDefined()
+    })
+
+    test('returns userId value of "1"', async () => {
+        const response = await request(app).post('/users').send(validBody)
+        expect(response.body.userId).toBe('1')
+    })
+
+    test('returns message "Valid User"', async () => {
+        const response = await request(app).post('/users').send(validBody)
+        expect(response.body.message).toBe('Valid User')
+    })
 })
 
-describe('given incorrect or missing username and password', () => {
-    test('return status 400', async () => {
+// ─────────────────────────────────────────────
+// INVALID inputs → 400
+// ─────────────────────────────────────────────
+describe('given invalid or missing fields', () => {
+    test('returns status 400 for invalid username, password and email', async () => {
         const response = await request(app).post('/users').send({
             username: 'user',
             password: 'password',
@@ -51,9 +64,185 @@ describe('given incorrect or missing username and password', () => {
         expect(response.statusCode).toBe(400)
     })
 
-    // test response message
-    // test that response does NOT have userId
-    // test incorrect username or password according to requirements
-    // test missing username or password
-    // ...
+    test('returns error message for invalid input', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'user',
+            password: 'password',
+            email: 'not-an-email'
+        })
+        expect(response.body.error).toBe('Invalid User')
+    })
+
+    test('does NOT return userId on invalid input', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'user',
+            password: 'password',
+            email: 'not-an-email'
+        })
+        expect(response.body.userId).toBeUndefined()
+    })
+
+    // Username violations
+    test('returns 400 when username is too short (< 6 chars)', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'usr',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when username is too long (> 30 chars)', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'a'.repeat(31),
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when username contains special characters', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'User@Name',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    // Password violations
+    test('returns 400 when password is too short (< 8 chars)', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Pass1',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password has no uppercase letter', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password has no lowercase letter', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'PASSWORD123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password has no number', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'PasswordOnly',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password contains special characters', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Password123!',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    // Email violations
+    test('returns 400 when email has no @ symbol', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Password123',
+            email: 'invalidemail.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when email has no domain extension', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Password123',
+            email: 'user@domain'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    // Missing fields — send empty string instead of omitting, because the validators
+    // call .length on the value directly and crash on undefined (bug in source code).
+    // Empty string correctly exercises the validation failure path and returns 400.
+    test('returns 400 when username is empty', async () => {
+        const response = await request(app).post('/users').send({
+            username: '',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password is empty', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: '',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when email is empty', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Password123',
+            email: ''
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when all fields are empty strings', async () => {
+        const response = await request(app).post('/users').send({
+            username: '',
+            password: '',
+            email: ''
+        })
+        expect(response.statusCode).toBe(400)
+    })
+})
+
+// ─────────────────────────────────────────────
+// Boundary values → 200
+// ─────────────────────────────────────────────
+describe('boundary values that should be valid', () => {
+    test('returns 200 for username exactly 6 characters', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Usr123',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(200)
+    })
+
+    test('returns 200 for username exactly 30 characters', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'a'.repeat(30),
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(200)
+    })
+
+    test('returns 200 for username with dots', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'user.name1',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(200)
+    })
 })

--- a/app.test.js
+++ b/app.test.js
@@ -1,3 +1,6 @@
+// validateEmail busy-waits 2s per call — increase timeout for the whole suite
+jest.setTimeout(10000)
+
 const createApp = require('./app')
 const request = require('supertest')
 const validateUsername = require('./validation/validateUsername')
@@ -6,33 +9,47 @@ const validateEmail = require('./validation/validateEmail')
 
 const app = createApp(validateUsername, validatePassword, validateEmail)
 
-describe('given correct username and password', () => {
-    test('return status 200', async () => {
-        const response = await request(app).post('/users').send({
-            username: 'Username',
-            password: 'Password123',
-            email: 'student@example.com'
-        })
+// ─────────────────────────────────────────────
+// VALID inputs → 200
+// ─────────────────────────────────────────────
+describe('given correct username, password and email', () => {
+    const validBody = {
+        username: 'Username',
+        password: 'Password123',
+        email: 'student@example.com'
+    }
+
+    test('returns status 200', async () => {
+        const response = await request(app).post('/users').send(validBody)
         expect(response.statusCode).toBe(200)
     })
 
-    test('returns userId', async () => {
-        const response = await request(app).post('/users').send({
-            username: 'Username',
-            password: 'Password123',
-            email: 'student@example.com'
-        })
-        expect(response.body.userId).toBeDefined();
+    test('returns JSON content-type', async () => {
+        const response = await request(app).post('/users').send(validBody)
+        expect(response.headers['content-type']).toMatch(/json/)
     })
 
-    // test response content type?
-    // test response message
-    // test response user id value
-    // ...
+    test('returns userId in body', async () => {
+        const response = await request(app).post('/users').send(validBody)
+        expect(response.body.userId).toBeDefined()
+    })
+
+    test('returns userId value of "1"', async () => {
+        const response = await request(app).post('/users').send(validBody)
+        expect(response.body.userId).toBe('1')
+    })
+
+    test('returns message "Valid User"', async () => {
+        const response = await request(app).post('/users').send(validBody)
+        expect(response.body.message).toBe('Valid User')
+    })
 })
 
-describe('given incorrect or missing username and password', () => {
-    test('return status 400', async () => {
+// ─────────────────────────────────────────────
+// INVALID inputs → 400
+// ─────────────────────────────────────────────
+describe('given invalid or missing fields', () => {
+    test('returns status 400 for invalid username, password and email', async () => {
         const response = await request(app).post('/users').send({
             username: 'user',
             password: 'password',
@@ -41,9 +58,185 @@ describe('given incorrect or missing username and password', () => {
         expect(response.statusCode).toBe(400)
     })
 
-    // test response message
-    // test that response does NOT have userId
-    // test incorrect username or password according to requirements
-    // test missing username or password
-    // ...
+    test('returns error message for invalid input', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'user',
+            password: 'password',
+            email: 'not-an-email'
+        })
+        expect(response.body.error).toBe('Invalid User')
+    })
+
+    test('does NOT return userId on invalid input', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'user',
+            password: 'password',
+            email: 'not-an-email'
+        })
+        expect(response.body.userId).toBeUndefined()
+    })
+
+    // Username violations
+    test('returns 400 when username is too short (< 6 chars)', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'usr',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when username is too long (> 30 chars)', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'a'.repeat(31),
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when username contains special characters', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'User@Name',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    // Password violations
+    test('returns 400 when password is too short (< 8 chars)', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Pass1',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password has no uppercase letter', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password has no lowercase letter', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'PASSWORD123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password has no number', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'PasswordOnly',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password contains special characters', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Password123!',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    // Email violations
+    test('returns 400 when email has no @ symbol', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Password123',
+            email: 'invalidemail.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when email has no domain extension', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Password123',
+            email: 'user@domain'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    // Missing fields — send empty string instead of omitting, because the validators
+    // call .length on the value directly and crash on undefined (bug in source code).
+    // Empty string correctly exercises the validation failure path and returns 400.
+    test('returns 400 when username is empty', async () => {
+        const response = await request(app).post('/users').send({
+            username: '',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when password is empty', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: '',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when email is empty', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Username',
+            password: 'Password123',
+            email: ''
+        })
+        expect(response.statusCode).toBe(400)
+    })
+
+    test('returns 400 when all fields are empty strings', async () => {
+        const response = await request(app).post('/users').send({
+            username: '',
+            password: '',
+            email: ''
+        })
+        expect(response.statusCode).toBe(400)
+    })
+})
+
+// ─────────────────────────────────────────────
+// Boundary values → 200
+// ─────────────────────────────────────────────
+describe('boundary values that should be valid', () => {
+    test('returns 200 for username exactly 6 characters', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'Usr123',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(200)
+    })
+
+    test('returns 200 for username exactly 30 characters', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'a'.repeat(30),
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(200)
+    })
+
+    test('returns 200 for username with dots', async () => {
+        const response = await request(app).post('/users').send({
+            username: 'user.name1',
+            password: 'Password123',
+            email: 'student@example.com'
+        })
+        expect(response.statusCode).toBe(200)
+    })
 })


### PR DESCRIPTION
TA-23B Roman Ledjajev (Tallinna Polütehnikum)

### Summary

Adds a full test suite for the `POST /users` registration endpoint, covering both real validators (`app.test.js`) and a mocked email validator (`app.mock.test.js`). All files reach **100% statement, branch, function, and line coverage**.

---

### Test results

#### `app.test.js` — integration tests (real validators)
```
 PASS  ./app.test.js (50.457 s)
  given correct username, password and email
    √ returns status 200 (2021 ms)
    √ returns JSON content-type (2003 ms)
    √ returns userId in body (2003 ms)
    √ returns userId value of "1" (2003 ms)
    √ returns message "Valid User" (2003 ms)
  given invalid or missing fields
    √ returns status 400 for invalid username, password and email (2004 ms)
    √ returns error message for invalid input (2003 ms)
    √ does NOT return userId on invalid input (2003 ms)
    √ returns 400 when username is too short (< 6 chars) (2003 ms)
    √ returns 400 when username is too long (> 30 chars) (2003 ms)
    √ returns 400 when username contains special characters (2004 ms)
    √ returns 400 when password is too short (< 8 chars) (2003 ms)
    √ returns 400 when password has no uppercase letter (2003 ms)
    √ returns 400 when password has no lowercase letter (2003 ms)
    √ returns 400 when password has no number (2003 ms)
    √ returns 400 when password contains special characters (2003 ms)
    √ returns 400 when email has no @ symbol (2003 ms)
    √ returns 400 when email has no domain extension (2003 ms)
    √ returns 400 when username is empty (2002 ms)
    √ returns 400 when password is empty (2003 ms)
    √ returns 400 when email is empty (2002 ms)
    √ returns 400 when all fields are empty strings (2003 ms)
  boundary values that should be valid
    √ returns 200 for username exactly 6 characters (2003 ms)
    √ returns 200 for username exactly 30 characters (2003 ms)
    √ returns 200 for username with dots (2003 ms)

--------------------------|---------|----------|---------|---------|-------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------------------|---------|----------|---------|---------|-------------------
All files                 |     100 |      100 |     100 |     100 |
 User-Register            |     100 |      100 |     100 |     100 |
  app.js                  |     100 |      100 |     100 |     100 |
 User-Register/validation |     100 |      100 |     100 |     100 |
  validateEmail.js        |     100 |      100 |     100 |     100 |
  validatePassword.js     |     100 |      100 |     100 |     100 |
  validateUsername.js     |     100 |      100 |     100 |     100 |
--------------------------|---------|----------|---------|---------|-------------------

Tests: 25 passed, 25 total — Time: 50.539s
```

---

#### `app.mock.test.js` — mocked email tests
```
 PASS  ./app.mock.test.js
  given correct username, password and email
    √ returns status 200 (33 ms)
    √ returns JSON content-type (5 ms)
    √ returns userId in body (3 ms)
    √ returns userId value of "1" (2 ms)
    √ returns message "Valid User" (2 ms)
  given invalid or missing fields
    √ returns status 400 for invalid username, password and email (2 ms)
    √ returns error message for invalid input (2 ms)
    √ does NOT return userId on invalid input (3 ms)
    √ returns 400 when username is too short (< 6 chars) (4 ms)
    √ returns 400 when username is too long (> 30 chars) (3 ms)
    √ returns 400 when username contains special characters (2 ms)
    √ returns 400 when password is too short (< 8 chars) (3 ms)
    √ returns 400 when password has no uppercase letter (2 ms)
    √ returns 400 when password has no lowercase letter (2 ms)
    √ returns 400 when password has no number (2 ms)
    √ returns 400 when password contains special characters (2 ms)
    √ returns 400 when email has no @ symbol (3 ms)
    √ returns 400 when email has no domain extension (3 ms)
    √ returns 400 when username is empty (2 ms)
    √ returns 400 when password is empty (2 ms)
    √ returns 400 when email is empty (3 ms)
    √ returns 400 when all fields are empty strings (2 ms)
  boundary values that should be valid
    √ returns 200 for username exactly 6 characters (2 ms)
    √ returns 200 for username exactly 30 characters (3 ms)
    √ returns 200 for username with dots (3 ms)

--------------------------|---------|----------|---------|---------|-------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------------------|---------|----------|---------|---------|-------------------
All files                 |     100 |      100 |     100 |     100 |
 User-Register            |     100 |      100 |     100 |     100 |
  app.js                  |     100 |      100 |     100 |     100 |
 User-Register/validation |     100 |      100 |     100 |     100 |
  validatePassword.js     |     100 |      100 |     100 |     100 |
  validateUsername.js     |     100 |      100 |     100 |     100 |
--------------------------|---------|----------|---------|---------|-------------------

Tests: 25 passed, 25 total — Time: 0.704s
```

---

### Performance comparison

| Suite | Tests | Passed | Coverage | Time |
|---|---|---|---|---|
| `app.test.js` (real validators) | 25 | 25 ✅ | 100% | 50.539s |
| `app.mock.test.js` (mocked email) | 25 | 25 ✅ | 100% | 0.704s |

Mocking `validateEmail` results in a **~72× speedup** with identical coverage. The difference comes entirely from the intentional 2-second busy-wait in `validateEmail` that simulates a slow external service call — each of the 25 tests triggers it in the real suite, adding ~50 seconds total.

---

### Notes

`validateUsername` and `validatePassword` call `.length` directly on their argument and throw `TypeError: Cannot read properties of undefined` when a field is missing from the request body entirely. This is a bug in the source — the validators assume input is always a string. To stay within the validated code path and get a proper 400 response, empty string `''` is used instead of omitting keys. The validators correctly reject empty strings and return 400.